### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -9,6 +9,9 @@ on:
     - '*'
   schedule:
   - cron: '0 18 * * 0'
+permissions:
+  contents: read
+  actions: write
 env:
   solution: './DBTestCompareGenerator.sln'
   buildPlatform: Any CPU


### PR DESCRIPTION
Potential fix for [https://github.com/Accenture/DBTestCompareGenerator/security/code-scanning/2](https://github.com/Accenture/DBTestCompareGenerator/security/code-scanning/2)

To fix the issue, we need to add an explicit `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow interacts with repository contents and uploads artifacts, we can set `contents: read` and `actions: write` permissions. These permissions will apply to all jobs unless overridden at the job level.

The `permissions` block should be added at the root level of the workflow file, ensuring that all jobs inherit these permissions unless explicitly overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
